### PR TITLE
fix(ci): read Go version from go.mod to fix Dependabot failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5  # v6.2.0
         with:
-          go-version: '1.25.7'
+          go-version-file: 'go.mod'
           cache: true
 
       - name: Install dependencies
@@ -66,7 +66,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5  # v6.2.0
         with:
-          go-version: '1.25.7'
+          go-version-file: 'go.mod'
           cache: true
 
       - name: Run tests


### PR DESCRIPTION
## Summary

- Replaces hardcoded `go-version: '1.25.7'` with `go-version-file: 'go.mod'` in the CI workflow
- Fixes 56% of all CI failures (5 out of 9 total), all on Dependabot PRs

## Problem

When Dependabot bumps a dependency whose `go.mod` requires a newer Go patch version (e.g., 1.25.8), it updates this repo's `go.mod` accordingly. But CI has `go-version: '1.25.7'` hardcoded, so it installs Go 1.25.7 regardless of what the PR's `go.mod` says. Go then refuses to build because the local toolchain can't satisfy the requirement:

```
go: go.mod requires go >= 1.25.8 (running go 1.25.7; GOTOOLCHAIN=local)
```

Affected runs: `24026659556`, `22847534701`, `21390107272`, `21390104238`, `21390089960`.

## Fix

Changed both `setup-go` steps in `ci.yml` (lint and test jobs) from:
```yaml
go-version: '1.25.7'
```
to:
```yaml
go-version-file: 'go.mod'
```

This makes CI read the Go version from `go.mod`, so when Dependabot updates the `go` directive, CI installs the matching version. `go-latest.yml` already uses `go-version: 'stable'` and needs no change.

## Verification

1. Next Dependabot PR that bumps a Go dependency should pass CI
2. Trigger the CI workflow via `workflow_dispatch` — should install Go 1.25.7 (current `go.mod` value) and pass
3. No behavior change for non-Dependabot PRs until `go.mod` is updated

---

> [!NOTE]
> Created by [Mendral](https://mendral.com). Tag @mendral-agent with feedback or questions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI pipeline configuration to manage Go toolchain version through project configuration file instead of hardcoded version specifications across build jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->