### PR TITLE
ci: cancel in-progress CI runs on new pushes to same branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
     branches: [main]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 


### PR DESCRIPTION
## Summary

- Adds `concurrency` block with `cancel-in-progress: true` to the CI workflow
- Prevents redundant CI runs when multiple commits are pushed to the same PR branch

## Problem

The CI workflow triggers on `pull_request` but has no `concurrency` configuration. Each push to a PR branch starts a full 8-job matrix (4-OS lint + 4-OS test). Rapid pushes stack up parallel runs for commits that are already superseded, wasting GitHub Actions minutes.

## Fix

Added a top-level `concurrency` block to `.github/workflows/ci.yml`:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

Runs are grouped by workflow name + branch ref. A new push to the same branch cancels any in-progress run for that branch. Push-to-main runs use the same grouping but don't overlap frequently enough for this to be an issue.

## Verification

1. Open a PR and push two commits within seconds — the first run should be cancelled
2. Push to `main` — should run to completion as normal
3. `workflow_dispatch` triggers are unaffected

---

> [!NOTE]
> Created by [Mendral](https://mendral.com). Tag @mendral-agent with feedback or questions.